### PR TITLE
Don't throw cryptic errors for bad initials

### DIFF
--- a/material-avatar.js
+++ b/material-avatar.js
@@ -224,6 +224,10 @@
       }
     }
 
+    index = index || 0;
+    while (index < 0) {
+      index += this.options.colorPalette.length;
+    }
     return this.options.colorPalette[index % this.options.colorPalette.length];
   };
 


### PR DESCRIPTION
When backgroundColor is undefined due to bad initials/a bad index, _hexToRgb generates a '.replace' related error that makes no sense.

Avoid this by not failing when input is not perfect.
- Handle a NaN index, usually due to empty initials/name
- Handle a negative index, like when initials end up with character codes less than 65.
- Don't throw an
